### PR TITLE
Add Aurora-Aurigami

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,6 +46,10 @@ const jobs = [
     file: 'ParseInverse',
     name: 'ethereum_inverse'
   },
+  {
+    file: 'ParseAurigami',
+    name: 'aurora_aurigami'
+  },
 ]
 
 for(let job of jobs) {

--- a/backgroundJobs/Addresses.js
+++ b/backgroundJobs/Addresses.js
@@ -65,8 +65,18 @@ const inverseAddress = { "ETH" : { "comptroller" : "0x4dCf7407AE5C07f8681e1659f6
                      "0xde2af899040536884e062D3a334F2dD36F34b4a4",
                      "0x697b4acAa24430F254224eB794d2a85ba1Fa1FB8"]} }
 
+const aurigamiAddress = {
+    "NEAR": {
+        "comptroller": "0x817af6cfAF35BdC1A634d6cC94eE9e4c68369Aeb",
+        "cETH": "0xca9511B610bA5fc7E311FDeF9cE16050eE4449E9",
+        "deployBlock": 60501454,
+        "blockStepInInit": 10000,
+        "multicallSize": 20
+    }
+}
+
 module.exports = {
     oneInchOracleAbi, cTokenAbi, comptrollerAbi, multicallAbi, erc20Abi: erc20Abi,
     compoundAddress, multicallAddress, oneInchOracleAddress, usdcAddress, venusAddress, rariTetranodeAddress, traderJoeAddress, benqiAddress, bastionAddress,
-    ironBankAddress, ovixAddress, apeSwapAddress, rikkiAddress, inverseAddress
+    ironBankAddress, ovixAddress, apeSwapAddress, rikkiAddress, inverseAddress, aurigamiAddress,
 }

--- a/backgroundJobs/CompoundParser.js
+++ b/backgroundJobs/CompoundParser.js
@@ -144,7 +144,11 @@ class Compound {
                 price = await getPrice(this.network, underlying, this.web3)
                 if(price.toString() == "0") {
                     console.log("trying with zapper")
-                    price = await getCTokenPriceFromZapper(market, underlying, this.web3, this.network)
+                    price = await getCTokenPriceFromZapper(market, underlying, this.web3, this.network).catch(e => {
+                        console.log("zapper failed", e)
+                        console.log("Use zero price");
+                        return toBN("0");
+                    })
                 }
                 const token = new this.web3.eth.Contract(Addresses.cTokenAbi, underlying)
                 balance = await token.methods.balanceOf(market).call()

--- a/backgroundJobs/ParseAurigami.js
+++ b/backgroundJobs/ParseAurigami.js
@@ -1,0 +1,15 @@
+const Addresses = require("./Addresses.js")
+const Compound = require("./CompoundParser")
+const Web3 = require("web3")
+require('dotenv').config()
+
+class AurigamiParser extends Compound {
+  constructor() {
+    const compoundInfo = Addresses.aurigamiAddress
+    const network = 'NEAR'
+    const web3 = new Web3(process.env.NEAR_NODE_URL)
+    super(compoundInfo, network, web3, 24 * 5)
+  }
+}
+
+module.exports = AurigamiParser


### PR DESCRIPTION
In this PR, we add Aurigami Parser and background jobs.

Aurigami is the native money market on Aurora.

Our website: https://www.aurigami.finance/ 

## Note

In Aurigami, we have a USN market which its price cannot be fetch with the current codebase. So I set its price as 0 so that all users that are in USN market will be ignored. 