### PR TITLE
fix market duplicates on compoundv3

### DIFF
--- a/backgroundJobs/CompoundV3Parser.js
+++ b/backgroundJobs/CompoundV3Parser.js
@@ -117,7 +117,7 @@ class CompoundV3 {
         console.log("get markets")
 
         // reset the markets otherwise we will always news markets added
-        // as duplicated to the array each times we init prices (every hours)
+        // (as duplicate) to the array each times we init prices (every hours)
         this.markets = [];
 
         // Add base token to markets

--- a/backgroundJobs/CompoundV3Parser.js
+++ b/backgroundJobs/CompoundV3Parser.js
@@ -116,6 +116,10 @@ class CompoundV3 {
     async initPrices() {
         console.log("get markets")
 
+        // reset the markets otherwise we will always news markets added
+        // as duplicated to the array each times we init prices (every hours)
+        this.markets = [];
+
         // Add base token to markets
         this.baseTokenAddress = await this.comet.methods.baseToken().call()
         this.markets.push(this.baseTokenAddress)


### PR DESCRIPTION
The compound markets were pushed to this.markets each times we entered initPrices(), making the tvl and total borrow x2 the second time, x3 the third etc...